### PR TITLE
Fix building of varnish-modules

### DIFF
--- a/SPEC/varnish-modules.spec
+++ b/SPEC/varnish-modules.spec
@@ -20,7 +20,7 @@ Collection of Varnish Cache modules (vmods) by Varnish Software
 
 %build
 ./bootstrap
-./configure --prefix=/usr/ --docdir='${datarootdir}/doc/%{name}'
+./configure --docdir='${datarootdir}/doc/%{name}'
 make
 
 %install


### PR DESCRIPTION
For some reason when configure get --prefix it will generate make file
that installs files to /usr/lib not to /usr/lib64.
Fortunately we can skip the prefix as it by default install it self in
/usr/ folder.

I've created an issue in varnish-modules maybe they will be interested
to fix that:
https://github.com/varnish/varnish-modules/issues/72